### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,20 +12,20 @@ Neo	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin	          KEYWORD2
-setBrightness	  KEYWORD2
-displayTest	    KEYWORD2
-append	        KEYWORD2
-renderDisplay		KEYWORD2
-setRow		      KEYWORD2
-clearDisplay	  KEYWORD2
-fillDisplay	    KEYWORD2
-shiftLeft		    KEYWORD2
-render          KEYWORD2
+begin	KEYWORD2
+setBrightness	KEYWORD2
+displayTest	KEYWORD2
+append	KEYWORD2
+renderDisplay	KEYWORD2
+setRow	KEYWORD2
+clearDisplay	KEYWORD2
+fillDisplay	KEYWORD2
+shiftLeft	KEYWORD2
+render	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-CH      LITERAL1
-SIGN    LITERAL1
+CH	LITERAL1
+SIGN	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords